### PR TITLE
Plan branches and add initial deck setup logic

### DIFF
--- a/docs/BRANCH_PLAN.md
+++ b/docs/BRANCH_PLAN.md
@@ -1,0 +1,26 @@
+# Branch Plan for Spider Solitaire
+
+This document describes the proposed branch strategy to implement the Spider Solitaire web game based on the SRS v0.1.
+
+## Branches
+
+- `main`: stable release branch. All completed features are merged here via pull requests.
+- `feature/scaffold`: initial project scaffold (React, Vite, Tailwind, Zustand, dnd-kit).
+- `feature/logic`: core game logic including deck generation, setup, move rules, and scoring.
+- `feature/ui`: components and pages (`HomePage`, `GamePage`, `SettingsPage`).
+- `feature/storage`: localStorage persistence and settings management.
+- `feature/animations`: card animations and responsive interactions.
+- `feature/tests`: unit and e2e tests covering gameplay rules.
+- `release/x.y`: tagged release branches prepared for deployment.
+
+Each feature branch is cut from `main` and merged back via pull request after review and testing.
+
+## Sprint Mapping
+
+| Sprint | Branches |
+|-------|----------|
+| 0 | `feature/scaffold` |
+| 1 | `feature/logic`, `feature/ui`, `feature/tests` |
+| 2 | `feature/animations`, `feature/storage` |
+| 3 | `release/x.y` |
+

--- a/src/logic/deck.js
+++ b/src/logic/deck.js
@@ -1,0 +1,41 @@
+// Deck generation and shuffling for Spider Solitaire
+// Using a seeded PRNG (mulberry32) for deterministic shuffles.
+
+function mulberry32(seed) {
+  let t = seed >>> 0;
+  return function () {
+    t += 0x6D2B79F5;
+    let r = t;
+    r = Math.imul(r ^ (r >>> 15), r | 1);
+    r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function generateSuits(difficulty) {
+  if (difficulty === 1) return ['S'];
+  if (difficulty === 2) return ['S', 'H'];
+  return ['S', 'H', 'D', 'C'];
+}
+
+function createDeck(difficulty = 1, seed = Date.now()) {
+  const suits = generateSuits(difficulty);
+  const repeats = 104 / (13 * suits.length); // 1:8, 2:4, 4:2
+  const cards = [];
+  let id = 0;
+  for (let r = 0; r < repeats; r++) {
+    for (const suit of suits) {
+      for (let rank = 1; rank <= 13; rank++) {
+        cards.push({ id: String(id++), suit, rank, faceUp: false });
+      }
+    }
+  }
+  const rng = mulberry32(seed);
+  for (let i = cards.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [cards[i], cards[j]] = [cards[j], cards[i]];
+  }
+  return cards;
+}
+
+module.exports = { createDeck, generateSuits, mulberry32 };

--- a/src/logic/setup.js
+++ b/src/logic/setup.js
@@ -1,0 +1,30 @@
+const { createDeck } = require('./deck.js');
+
+function initialDeal(difficulty = 1, seed = Date.now()) {
+  const deck = createDeck(difficulty, seed);
+  const columns = [];
+  let index = 0;
+  for (let c = 0; c < 10; c++) {
+    const count = c < 4 ? 6 : 5;
+    const column = { id: `col${c}`, cards: [] };
+    for (let i = 0; i < count; i++) {
+      const card = deck[index++];
+      card.faceUp = i === count - 1;
+      column.cards.push(card);
+    }
+    columns.push(column);
+  }
+  const stock = [];
+  for (let batch = 0; batch < 5; batch++) {
+    const batchCards = [];
+    for (let j = 0; j < 10; j++) {
+      const card = deck[index++];
+      card.faceUp = false;
+      batchCards.push(card);
+    }
+    stock.push(batchCards);
+  }
+  return { columns, stock };
+}
+
+module.exports = { initialDeal };

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { createDeck } = require('../src/logic/deck.js');
+const { initialDeal } = require('../src/logic/setup.js');
+
+test('createDeck deterministic with seed', () => {
+  const d1 = createDeck(1, 123);
+  const d2 = createDeck(1, 123);
+  assert.deepStrictEqual(d1, d2);
+});
+
+test('initialDeal creates correct structure', () => {
+  const { columns, stock } = initialDeal(1, 123);
+  assert.equal(columns.length, 10);
+  const firstFour = columns.slice(0,4).every(col => col.cards.length === 6);
+  const lastSix = columns.slice(4).every(col => col.cards.length === 5);
+  assert.equal(firstFour, true);
+  assert.equal(lastSix, true);
+  const faceUpCount = columns.filter(col => col.cards[col.cards.length - 1].faceUp).length;
+  assert.equal(faceUpCount, 10);
+  assert.equal(stock.length, 5);
+  assert.equal(stock.every(batch => batch.length === 10), true);
+});


### PR DESCRIPTION
## Summary
- add branch planning document for spider solitaire project
- implement seeded deck generation and initial deal logic
- cover deterministic shuffle and dealing with basic tests

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68c19a4a95188333b48f7b49740032f3